### PR TITLE
Update Utils.pm - Fix Trim_spaces to remove UTF-8 BOM (Byte Order Mark)

### DIFF
--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -829,7 +829,7 @@ sub writeTimingLogEntry {
 sub trim_spaces {
 	my $in = shift;
 	return '' unless $in;    # skip blank spaces
-	$in =~ s/^\x{FEFF}//;    # fix UTF-8 without BOM 
+	$in =~ s/^\x{FEFF}//;    # fix UTF-8 with BOM 
 	$in =~ s/^\s*|\s*$//g;
 	return ($in);
 }

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -829,7 +829,7 @@ sub writeTimingLogEntry {
 sub trim_spaces {
 	my $in = shift;
 	return '' unless $in;    # skip blank spaces
- 	$in =~ s/^\x{FEFF}//;    # fix UTF-8 without BOM 
+	$in =~ s/^\x{FEFF}//;    # fix UTF-8 without BOM 
 	$in =~ s/^\s*|\s*$//g;
 	return ($in);
 }

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -829,6 +829,7 @@ sub writeTimingLogEntry {
 sub trim_spaces {
 	my $in = shift;
 	return '' unless $in;    # skip blank spaces
+ 	$in =~ s/^\x{FEFF}//;    # fix UTF-8 without BOM 
 	$in =~ s/^\s*|\s*$//g;
 	return ($in);
 }

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -829,7 +829,7 @@ sub writeTimingLogEntry {
 sub trim_spaces {
 	my $in = shift;
 	return '' unless $in;    # skip blank spaces
-	$in =~ s/^\x{FEFF}//;    # fix UTF-8 with BOM 
+	$in =~ s/^\x{FEFF}//;    # fix UTF-8 with BOM
 	$in =~ s/^\s*|\s*$//g;
 	return ($in);
 }


### PR DESCRIPTION
Always when we have a csv in UTF-8 with BOM we have a error "Wide character in crypt" error message when passwords with certain "wide" characters.

We don't have control over where the files are created to be imported. Normally they use a CSV file and then use Excel to export it in UTF-8(the professors who own this course follow this process). However, this specific file came with a BOM. We use this list to import students into WebWork,, and whenever there's a BOM, we encounter the 'Wide character in crypt' error.
I have attached two files, one with a BOM and one without a BOM. Our workflow involves uploading the list to WebWork and import the list: WeBWorK -> TEMP Course Tests -> Instructor Tools -> Classlist Editor -> Import users from what file> -> <file_w_BOM> -> Import

```
╰─$ hexdump -n 3 -C StudentsList_course_csv_utf-8_w_BOM.csv                                                                                                                                                                                 130 ↵
00000000  ef bb bf                                          |...|
00000003
```

```
╰─$ hexdump -n 3 -C StudentsList_course_csv_utf-8_withot_BOM.csv
00000000  32 33 37                                          |237|
00000003
```

Remove UTF-8 BOM (Byte Order Mark):

Line 832: $in =~ s/^\x{FEFF}//;
This line removes the UTF-8 BOM (represented by the Unicode character U+FEFF) from the beginning of the input string.

[StudentsList_course_csv_utf-8_w_BOM.csv](https://github.com/tm-lcarvalho/webwork2/files/14039773/StudentsList_course_csv_utf-8_w_BOM.csv)
[StudentsList_course_csv_utf-8_withot_BOM.csv](https://github.com/tm-lcarvalho/webwork2/files/14039774/StudentsList_course_csv_utf-8_withot_BOM.csv)
